### PR TITLE
fix: publish btp workflow

### DIFF
--- a/.github/workflows/publish-btp.yml
+++ b/.github/workflows/publish-btp.yml
@@ -33,6 +33,7 @@ jobs:
             examples/ui5-ts-app/mta_archives/ui5-approuter_1.0.0.mtar
 
   publish-sample-ts-app-to-btp:
+    needs: build-sample-ts-app
     runs-on: ubuntu-latest
     container: ppiper/cf-cli
     steps:


### PR DESCRIPTION
both jobs run on the same time, but the job `publish-sample-ts-app-to-btp` depends on the build from job `build-sample-ts-app` That´s why deploy job failed because the artifact simply does not exist yet

closes #432